### PR TITLE
controller v5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,33 @@
-FROM debian:9-slim
-# controller has really old deps, they've told me v5 will address this
-# for now, stretch is the easy answer
-
+FROM debian:10-slim as builder
 RUN apt update && \
     apt -y upgrade && \
-    apt -y install mongodb openjdk-8-jre-headless curl jsvc procps net-tools libcap2 && \
+    apt -y install make gcc default-jdk-headless curl libcap-dev && \
+    curl -fsSL https://dlcdn.apache.org//commons/daemon/source/commons-daemon-1.2.4-src.tar.gz -o /opt/apache.tgz && \
+    tar -xzf /opt/apache.tgz --strip-components=1 -C /opt && \
+    rm /opt/apache.tgz
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+WORKDIR /opt/src/native/unix
+RUN ./configure && \
+    make
+
+FROM debian:10-slim
+# controller has old deps
+# install deps other than mongo
+# then mongo
+# the copy in custom jsvc because its trash until version 1.2.3 (which is very new), and requires jdk8 otherwise
+RUN apt update && \
+    apt -y upgrade && \
+    apt -y install curl libc6 procps net-tools libcap2 gnupg default-jre-headless && \
+    curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - && \
+    echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main" > /etc/apt/sources.list.d/mongodb-org-5.0.list && \
+    apt update && \
+    apt install -y mongodb-org && \
+    apt -y purge gnupg && \
+    apt -y autoremove && \
     apt purge && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
+COPY --from=builder /opt/src/native/unix/jsvc /usr/bin/jsvc
 
 ENV OMADA_USER=root
 WORKDIR /opt
@@ -19,8 +39,9 @@ ARG VERSION
 # seriously what is even this URL format, why have year and year+month folders if there's a year+month+day folder within
 # cmon tp-link
 # also why even bother with dates if you're using semver it just makes things uglier and harder to automate
+# note: strip-components in untar since v5 to remove top-level folder in tarball that's versioned and unnecessary here
 RUN curl -fsSL https://static.tp-link.com/upload/software/${YEAR}/${YEAR}${MONTH}/${YEAR}${MONTH}${DAY}/Omada_SDN_Controller_v${VERSION}_linux_x64.tar.gz -o /opt/omada.tgz && \
-    tar -xzf /opt/omada.tgz && \
+    tar -xzf /opt/omada.tgz --strip-components=1 && \
     rm /opt/omada.tgz && \
     sed -i '/${link_name} start/d' install.sh && \
     bash install.sh -y

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,12 +5,12 @@ services:
     build:
       context: .
       args:
-        YEAR: 2021
-        MONTH: 12
-        DAY: 17
-        VERSION: 4.4.8
+        YEAR: "2022"
+        MONTH: "01"
+        DAY: "07"
+        VERSION: "5.0.29"
     container_name: omada
-    image: tarfeef101/omada_controller:4.4.8
+    image: tarfeef101/omada_controller:5.0.29
     stop_grace_period: 30s
     ports:
       - '8088:8088' 


### PR DESCRIPTION
god this was pain:
- despite them claiming "newer deps", still don't support debian 11 (nor does mongo, tbf), mongo >= 5, and they use `jsvc` which almost no distro has the `1.2.3` patch for, meaning it relies on jdk8 still
- had to compile my own jdk8 to fix this
- newer debian requires using mongo repos for installing mongo